### PR TITLE
Addition of a possible solution for the dockerization of the app using PHP5.6 and the PDO plugin.

### DIFF
--- a/workshop-steps/02-dockerize/.solutions/dockerfile_php5.6_pdo/Dockerfile
+++ b/workshop-steps/02-dockerize/.solutions/dockerfile_php5.6_pdo/Dockerfile
@@ -1,0 +1,42 @@
+# Use the official PHP image.
+# https://hub.docker.com/_/php
+FROM php:5.6-apache
+
+# Configure PHP for Cloud Run.
+# Precompile PHP code with opcache.
+# Install PHP's extension for MySQL
+RUN docker-php-ext-install -j "$(nproc)" opcache mysqli pdo pdo_mysql && docker-php-ext-enable pdo_mysql
+RUN set -ex; \
+  { \
+    echo "; Cloud Run enforces memory & timeouts"; \
+    echo "memory_limit = -1"; \
+    echo "max_execution_time = 0"; \
+    echo "; File upload at Cloud Run network limit"; \
+    echo "upload_max_filesize = 32M"; \
+    echo "post_max_size = 32M"; \
+    echo "; Configure Opcache for Containers"; \
+    echo "opcache.enable = On"; \
+    echo "opcache.validate_timestamps = Off"; \
+    echo "; Configure Opcache Memory (Application-specific)"; \
+    echo "opcache.memory_consumption = 32"; \
+  } > "$PHP_INI_DIR/conf.d/cloud-run.ini"
+
+# Copy in custom code from the host machine.
+WORKDIR /var/www/html
+# ./ /var/www/html
+COPY . .
+
+# Use the PORT environment variable in Apache configuration files.
+# https://cloud.google.com/run/docs/reference/container-contract#port
+# Setup the PORT variable
+ENV PORT=8080
+RUN sed -i 's/80/${PORT}/g' /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf
+
+# Configure PHP for development.
+# Switch to the production php.ini for production operations.
+# RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+# https://github.com/docker-library/docs/blob/master/php/README.md#configuration
+RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+
+# Expose the port
+EXPOSE 8080

--- a/workshop-steps/02-dockerize/.solutions/dockerfile_php5.6_pdo/Makefile
+++ b/workshop-steps/02-dockerize/.solutions/dockerfile_php5.6_pdo/Makefile
@@ -1,0 +1,2 @@
+docker build -t my-php-app-docker app-mod-workshop/ -f Dockerfile
+docker run -it -p 8080:8080 my-php-app-docker


### PR DESCRIPTION
As stated in the title, this is a possible solution to dockerize the application using an outdated version of PHP. The Dockerfile already takes care of the PDO plugin (thanks to StackOverflow) to allow the app to escape input strings and interact with the DB. Tested on Ubuntu 24.04 on kernel 5.18.

## Summary by Sourcery

Build:
- Add a Makefile to automate the Docker build and run process for the PHP 5.6 application.